### PR TITLE
reduced deferrals by 5 minutes

### DIFF
--- a/Renew.sh
+++ b/Renew.sh
@@ -503,7 +503,7 @@ uptime_days="$(( uptime_hours / 24 ))"
 
 debug_message "Uptime values are: $uptime_days days = $uptime_hours hours = $uptime_minutes minutes = $uptime_seconds seconds"
 
-deferUntilSeconds=$((deferralDuration * 60 * 60))
+deferUntilSeconds=$((deferralDuration * 60 * 60 - 300))
 deferUntil=$((current_unix_time+deferUntilSeconds))
 
 debug_message "Defer Until: "$deferUntil" which is $(date -j -f %s $deferUntil)"


### PR DESCRIPTION
This will cause Renew to behave more reliably close to the configured deferral time.