### PR TITLE
Fix for duplicate assertions

### DIFF
--- a/Renew.sh
+++ b/Renew.sh
@@ -691,7 +691,7 @@ fi
 checkForAssertion=$(pmset -g | grep "display sleep prevented by"| sed 's/.*(\(.*\))/\1/' | sed 's/display sleep prevented by //'| sed 's/,//g')
 
 for i in "${assertionsToIgnore[@]}"; do
-	checkForAssertion=$(echo "$checkForAssertion" | sed "s/$i//" | xargs )
+	checkForAssertion=$(echo "$checkForAssertion" | sed "s/$i//g" | xargs )
 done
 	
 if [ -n "$checkForAssertion" ]; then


### PR DESCRIPTION
This should fix the issues detected in #86 
Tested by running two instances of `caffeinate` and then running nudge with `--dry-run`
The modified code correctly removed both entries for `caffeinate` but not the entry for `firefox`