### PR TITLE
Assertions to ignore additions

### DIFF
--- a/ProfileManifest/com.secondsonconsulting.renew.plist
+++ b/ProfileManifest/com.secondsonconsulting.renew.plist
@@ -427,6 +427,27 @@ A profile can consist of payloads with different version numbers. For example, c
 					<key>pfm_title</key>
 					<string>Additional Notification Options</string>
 				</dict>
+                <dict>
+					<key>pfm_description</key>
+					<string>The applications which Renew ignores when checking for display assertions. (You can specify one or more, EX: zoom.us firefox).</string>
+					<key>pfm_documentation_url</key>
+					<string></string>
+					<key>pfm_name</key>
+					<string>IgnoreAssertions</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_title</key>
+							<string>Applications</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+					</array>
+					<key>pfm_title</key>
+					<string>Applications to ignore</string>
+					<key>pfm_type</key>
+					<string>array</string>
+				</dict>
 				<dict>
 					<key>pfm_description</key>
 					<string>Use this option to enable "Deadline" mode. If a device's uptime exceeds the "Deadline" value in days, Renew will enter Aggressive Mode regardless of the remaining deferrals.</string>

--- a/Renew.sh
+++ b/Renew.sh
@@ -78,8 +78,7 @@ if [ "$logLength" -ge 3000 ]; then
 fi
 
 #Path to mobileconfig payload
-#renewConfig="/Library/Managed Preferences/com.secondsonconsulting.renew.plist"
-renewConfig="/private/var/tmp/com.secondsonconsulting.renew.plist"
+renewConfig="/Library/Managed Preferences/com.secondsonconsulting.renew.plist"
 
 #Path to swiftDialog binary
 dialogPath='/usr/local/bin/dialog'

--- a/Renew.sh
+++ b/Renew.sh
@@ -78,7 +78,8 @@ if [ "$logLength" -ge 3000 ]; then
 fi
 
 #Path to mobileconfig payload
-renewConfig="/Library/Managed Preferences/com.secondsonconsulting.renew.plist"
+#renewConfig="/Library/Managed Preferences/com.secondsonconsulting.renew.plist"
+renewConfig="/private/var/tmp/com.secondsonconsulting.renew.plist"
 
 #Path to swiftDialog binary
 dialogPath='/usr/local/bin/dialog'
@@ -643,6 +644,15 @@ fi
 
 #By default, we wnat to ignore some specific app assertions (caffeinate, Amphetamine, obs). These aren't actual indicators of what we're looking for.
 assertionsToIgnore=()
+
+#If the admin has set any items in the config add them to assertionsToIgnore
+count=0
+until ! "$pBuddy" -c "Print :OptionalArguments:IgnoreAssertions:$count" $renewConfig > /dev/null 2>&1; do
+    assertionsToIgnore+=$("$pBuddy" -c "Print :OptionalArguments:IgnoreAssertions:$count" $renewConfig)
+    count=$(( count + 1 ))
+done
+
+#Default Ignore List
 assertionsToIgnore+="obs"
 assertionsToIgnore+="Amphetamine"
 assertionsToIgnore+="caffeinate"


### PR DESCRIPTION
Added code to allow additional options for Assertions to Ignore via config profile.
Added basic Profile Manifest additions, this specifically will need to be checked as I have never done Profile Manifest work before!